### PR TITLE
Added basic centralized logging

### DIFF
--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -1,0 +1,33 @@
+package log
+
+import (
+	"log"
+)
+
+type LogMessage struct {
+	JSONPayload string
+}
+
+type LogPublisher interface {
+	// publishes a message to all web hook subscriptions
+	Publish(message *LogMessage) error
+}
+
+type logPublisher struct {
+	logMode string
+	sender  string
+}
+
+func NewLogPublisher(sender string, logMode string) LogPublisher {
+	publisher := &logPublisher{sender: sender, logMode: logMode}
+
+	return publisher
+}
+
+func (p *logPublisher) Publish(message *LogMessage) error {
+	log.Printf("recieved logged mesage: %s", message)
+
+	// TODO: write to open telemetry which will write to app insights
+
+	return nil
+}

--- a/internal/log/log_test.go
+++ b/internal/log/log_test.go
@@ -1,0 +1,11 @@
+package log
+
+import "testing"
+
+func TestLogger(t *testing.T) {
+	myLogger := NewLogPublisher("", "")
+	myMsg := LogMessage{
+		JSONPayload: "hello world!!!",
+	}
+	myLogger.Publish(&myMsg)
+}


### PR DESCRIPTION
Ashwin and I added a basic logging package under internal/log. This package can be imported by the apiserver, operator to log to a central package.

Todo: add open telemetry and then add app insights exporter.