### PR TITLE
feat: 94 dryrun async

### DIFF
--- a/cmd/operator/operations/dryrun.go
+++ b/cmd/operator/operations/dryrun.go
@@ -44,6 +44,7 @@ func (o *dryRunOperation) sendEvent(eventMessage *events.WebHookEventMessage) er
 	if err != nil {
 		return err
 	}
+	
 	if len(results) > 0 {
 		for _, result := range results {
 			if result.Error != nil {


### PR DESCRIPTION
This PR makes the following changes in support of Issue #94.

1. Grabs the results of the DryRun operation and sends them to the events queue for publication to the subscribing web hook.
2. Adds DryRun call to the test harness.

