### PR TITLE
Added env for target github account and version prefix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,10 @@
 
 name: CI
 
+env:
+  targetGitHubAccount: kevinmgates
+  versionPrefix: v0.1.
+
 on:
   push:
     branches: [ "main" ]
@@ -45,9 +49,9 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
     - name: Login to GitHub Container Registry
-      run: echo ${{ secrets.CR_PAT }} | docker login ghcr.io -u kevinmgates --password-stdin
-    - name: Build and push
+      run: echo ${{ secrets.CR_PAT }} | docker login ghcr.io -u ${{ env.targetGitHubAccount }} --password-stdin
+    - name: Build and push to registry
       uses: docker/build-push-action@v4
       with:
         push: true
-        tags: ghcr.io/kevinmgates/modm:${{github.run_number}}
+        tags: ghcr.io/${{ env.targetGitHubAccount }}/modm:${{ env.versionPrefix }}${{github.run_number}}


### PR DESCRIPTION
Until I configure the container registry against our org account, this will publish container images to my [container registry](https://github.com/users/kevinmgates/packages/container/package/modm). To make it easier to change later, I added variables for the target github account/org and updated the image tag to v0.1.x per #99.