### PR TITLE
bug: fixing event subscription bug with url

### DIFF
--- a/cmd/apiserver/app/eventgridregistration.go
+++ b/cmd/apiserver/app/eventgridregistration.go
@@ -18,7 +18,7 @@ func newEventGridRegistrationTask(appConfig *config.AppConfig) tasks.Task {
 	taskOptions := eventGridRegistrationTaskOptions{
 		Credential:      hosting.GetAzureCredential(),
 		ResourceGroupId: appConfig.Azure.GetResourceGroupId(),
-		EndpointUrl:     appConfig.GetPublicBaseUrl() + "/eventgrid",
+		EndpointUrl:     appConfig.GetPublicBaseUrl() + "eventgrid",
 	}
 	task := create(taskOptions)
 

--- a/deployments/docker-compose.yml
+++ b/deployments/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - PORT=8080
   modm:
     env_file: ../bin/.env
-    image: gpsuscodewith/modm:v0.1.18
+    image: gpsuscodewith/modm:latest
     ports:
       - 8080:8080
     environment:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -47,7 +47,7 @@ func (s *AppConfig) GetPublicBaseUrl() string {
 	if !s.IsDevelopment() {
 		protocol = "https"
 	}
-	return protocol + "https://" + s.Http.DomainName + "/"
+	return protocol + "://" + s.Http.DomainName + "/"
 }
 
 type AppConfig struct {


### PR DESCRIPTION
This PR fixes a bug when wiring up event subscriptions on startup.

It does the following:
- Removes double protocol append in the uri construction (httpshttps -> https)
- Removes double trailing slash in uri construction (//eventgrid -> /eventgrid)
- Adds the latest label to the docker image in the docker compose file