### PR TITLE
Feature: apiserver/handlers - CreateEventHook idempotency

### DIFF
--- a/api/2023-03-01-preview/api.json
+++ b/api/2023-03-01-preview/api.json
@@ -611,9 +611,9 @@
           "type": "string",
           "description": "the name of the subscription"
         },
-        "ApiKey":{
+        "apiKey":{
           "type": "string",
-          "description": "API key to be used in the Authorization header, e.g. 'ApiKey =234dfsdf324234', to call the webhook callback URL."
+          "description": "API key to be used in the Authorization header, e.g. 'apiKey =234dfsdf324234', to call the webhook callback URL."
         },
         "callback": {
           "type": "string",

--- a/cmd/apiserver/handlers/deployment_create.go
+++ b/cmd/apiserver/handlers/deployment_create.go
@@ -35,7 +35,7 @@ func (h *createDeploymentHandler) Handle(c echo.Context) error {
 	}
 
 	tx := h.db.Create(&deployment)
-	log.Debug("Deployment [%d] created.", deployment.ID)
+	log.Debugf("Deployment [%d] created.", deployment.ID)
 
 	if tx.Error != nil {
 		return err

--- a/cmd/apiserver/handlers/eventgrid_webhook.go
+++ b/cmd/apiserver/handlers/eventgrid_webhook.go
@@ -112,7 +112,7 @@ func NewEventGridWebHookHandler(appConfig *config.AppConfig, credential azcore.T
 
 		if len(errors) > 0 {
 			err = utils.NewAggregateError(errors)
-			log.Error("Failed to create event grid webhook handler: %s", err.Error())
+			log.Errorf("Failed to create event grid webhook handler: %s", err.Error())
 			return echo.NewHTTPError(http.StatusInternalServerError, "Internal server error")
 		}
 

--- a/cmd/apiserver/handlers/eventgrid_webhook_test.go
+++ b/cmd/apiserver/handlers/eventgrid_webhook_test.go
@@ -80,7 +80,7 @@ func getAppConfig() *config.AppConfig {
 	name := "test"
 	config.LoadConfiguration("testdata", &name, appConfig)
 
-	log.Debug("appConfig: %+v", appConfig)
+	log.Debugf("appConfig: %+v", appConfig)
 	return appConfig
 }
 

--- a/cmd/apiserver/handlers/eventhook_create_test.go
+++ b/cmd/apiserver/handlers/eventhook_create_test.go
@@ -1,0 +1,55 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/microsoft/commercial-marketplace-offer-deploy/internal/data"
+	testutils "github.com/microsoft/commercial-marketplace-offer-deploy/test/utils"
+	"github.com/stretchr/testify/assert"
+	"gorm.io/gorm"
+)
+
+func TestCreateEventHookIsIdempotentByName(t *testing.T) {
+	db := getInMemoryDb()
+
+	json, err := testutils.ReaderFromJsonFile("testdata/eventhook.json")
+	assert.NoError(t, err)
+
+	e := echo.New()
+	defer e.Close()
+
+	request := httptest.NewRequest(http.MethodPost, "/", json)
+	request.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	recorder := httptest.NewRecorder()
+	c := e.NewContext(request, recorder)
+
+	//act
+	err = CreateEventHook(c, db)
+	assert.NoError(t, err)
+
+	t.Log(recorder.Body.String())
+	assert.Equal(t, http.StatusOK, recorder.Code)
+
+	json, _ = testutils.ReaderFromJsonFile("testdata/eventhook.json")
+	request = httptest.NewRequest(http.MethodPost, "/", json)
+	request.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	recorder = httptest.NewRecorder()
+	c = e.NewContext(request, recorder)
+
+	err = CreateEventHook(c, db)
+	assert.NoError(t, err)
+	t.Log(recorder.Body.String())
+
+	assert.Equal(t, http.StatusOK, recorder.Code)
+}
+
+func getInMemoryDb() *gorm.DB {
+	databaseOptions := &data.DatabaseOptions{
+		UseInMemory: true,
+	}
+	db := data.NewDatabase(databaseOptions).Instance()
+	return db
+}

--- a/cmd/apiserver/handlers/testdata/eventhook.json
+++ b/cmd/apiserver/handlers/testdata/eventhook.json
@@ -1,0 +1,5 @@
+{
+    "name": "test-hook",
+    "apiKey": "12345",
+    "callback": "http://testcallback"
+}

--- a/pkg/api/zz_generated_models.go
+++ b/pkg/api/zz_generated_models.go
@@ -23,8 +23,8 @@ type CreateDeployment struct {
 }
 
 type CreateEventHookRequest struct {
-	// API key to be used in the Authorization header, e.g. 'ApiKey =234dfsdf324234', to call the webhook callback URL.
-	APIKey *string `json:"ApiKey,omitempty"`
+	// API key to be used in the Authorization header, e.g. 'apiKey =234dfsdf324234', to call the webhook callback URL.
+	APIKey *string `json:"apiKey,omitempty"`
 
 	// The webhook callback
 	Callback *string `json:"callback,omitempty"`

--- a/pkg/api/zz_generated_models_serde.go
+++ b/pkg/api/zz_generated_models_serde.go
@@ -62,7 +62,7 @@ func (c *CreateDeployment) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type CreateEventHookRequest.
 func (c CreateEventHookRequest) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "ApiKey", c.APIKey)
+	populate(objectMap, "apiKey", c.APIKey)
 	populate(objectMap, "callback", c.Callback)
 	populate(objectMap, "name", c.Name)
 	return json.Marshal(objectMap)
@@ -77,7 +77,7 @@ func (c *CreateEventHookRequest) UnmarshalJSON(data []byte) error {
 	for key, val := range rawMsg {
 		var err error
 		switch key {
-		case "ApiKey":
+		case "apiKey":
 				err = unpopulate(val, "APIKey", &c.APIKey)
 				delete(rawMsg, key)
 		case "callback":


### PR DESCRIPTION
- fixing compiler warnings about Debug"f" missing for formatted log entry calls
- Making idempotent based on if the hook already exists
- Adding test
- Fixing CamelCase APIKey on event hook in the API definition.