### PR TITLE
Bobjac/log fix

### DIFF
--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -41,11 +41,15 @@ func ConfigureLogging(config *LoggingOptions) {
 		return
 	}
 
+	fmt.Println("default log level: ", config.DefaultLogLevel)
+
 	logLevel := logrus.TraceLevel
 	if len(config.DefaultLogLevel) > 0 {
 		logLevel = getLogorusLevel(config.DefaultLogLevel)
 	}
 	logrus.SetLevel(logLevel)
+
+	fmt.Println("log level set to: ", logLevel)
 
 	if len(config.FilePath) > 0 {
 		stacktraceHook := &StacktraceHook{

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -3,6 +3,7 @@ package log
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 )
@@ -25,9 +26,8 @@ type InsightsConfig struct {
 	Version string
 }
 
-func ConfigureLogging(config *LoggingOptions) {
+func ConfigureLogging(config *LoggingOptions) {	
 	logrus.SetOutput(os.Stdout)
-	logrus.SetLevel(logrus.DebugLevel)
 	logrus.SetReportCaller(true)
 
 	formatter := &logrus.TextFormatter{
@@ -41,6 +41,12 @@ func ConfigureLogging(config *LoggingOptions) {
 		return
 	}
 
+	logLevel := logrus.TraceLevel
+	if len(config.DefaultLogLevel) > 0 {
+		logLevel = getLogorusLevel(config.DefaultLogLevel)
+	}
+	logrus.SetLevel(logLevel)
+
 	if len(config.FilePath) > 0 {
 		stacktraceHook := &StacktraceHook{
 			innerHook: &FileHook{
@@ -49,4 +55,21 @@ func ConfigureLogging(config *LoggingOptions) {
 		}
 		logrus.AddHook(stacktraceHook)
 	}
+}
+
+func getLogorusLevel(level string) logrus.Level {
+    switch strings.ToLower(level) {
+    case "debug":
+        return logrus.DebugLevel
+    case "info":
+        return logrus.InfoLevel
+    case "warn":
+        return logrus.WarnLevel
+    case "error":
+        return logrus.ErrorLevel
+	case "trace":
+		return logrus.TraceLevel
+    default:
+        return logrus.InfoLevel
+    }
 }


### PR DESCRIPTION
Simple fix for setting log level by configuration.

Inside log.go, I am using fmt.Println to print out the setting of the logging info before it is actually set up.
