### PR TITLE
fixing bug 311

### DIFF
--- a/internal/mapper/invokedoperation_eventhook.go
+++ b/internal/mapper/invokedoperation_eventhook.go
@@ -85,7 +85,7 @@ func getRetryStageData(operation *model.InvokedOperation) any {
 }
 
 func getDryRunData(invokedOperation *model.InvokedOperation) any {
-	resultStatus := sdk.StatusError.String()
+	resultStatus := invokedOperation.Status
 	result := invokedOperation.LatestResult().Value
 
 	data := &sdk.DryRunEventData{


### PR DESCRIPTION
### Bug Fix for incorrect DryRun status in EventHook
Prior to executing the DryRun command, incorrect statuses were sent in event hook messages. The Status was being defaulted to error instead of the status on the InvokedOperation.

Closes #311 