### PR TITLE
Credentials implementation for Jenkins

### DIFF
--- a/build/container/Dockerfile.jenkins
+++ b/build/container/Dockerfile.jenkins
@@ -21,8 +21,10 @@ RUN apt-get install terraform
 ENV JAVA_OPTS=-Djenkins.install.runSetupWizard=false
 RUN echo 2.0 > /usr/share/jenkins/ref/jenkins.install.UpgradeWizard.state
 
+# add initialization hooks
+# more info: https://www.jenkins.io/doc/book/managing/groovy-hook-scripts/
 RUN mkdir -p $JENKINS_HOME/init.groovy.d
-COPY jenkins/init-hooks/basic-security.groovy $JENKINS_HOME/init.groovy.d
+COPY jenkins/init-hooks/*.groovy $JENKINS_HOME/init.groovy.d
 
 # plugins
 USER jenkins

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,3 +15,6 @@ services:
     environment:
       - JAVA_OPTS=-Djenkins.install.runSetupWizard=false
       - DEFAULT_ADMIN_PASSWORD=admin
+      - AZURE_SUBSCRIPTION_ID=${AZURE_SUBSCRIPTION_ID}
+      - AZURE_CLIENT_ID=${AZURE_CLIENT_ID}
+      - AZURE_CLIENT_SECRET=${AZURE_SUBSCRIPTION_ID}

--- a/jenkins/init-hooks/azure-credentials.groovy
+++ b/jenkins/init-hooks/azure-credentials.groovy
@@ -1,0 +1,57 @@
+#!groovy
+
+// This script will add the Azure Credentials that can be used within Jobs
+//      it will select either a ServicePrincipal or Managed Identity credential 
+//      based on the presence of environment variables present
+
+import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl
+import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl
+import org.jenkinsci.plugins.plaincredentials.impl.FileCredentialsImpl
+import com.cloudbees.plugins.credentials.domains.Domain
+import com.cloudbees.plugins.credentials.CredentialsScope
+import jenkins.model.Jenkins
+import com.microsoft.azure.util.AzureImdsCredentials
+import com.microsoft.azure.util.AzureCredentials
+
+final SYSTEM_CREDENTIALS_PROVIDER = 'com.cloudbees.plugins.credentials.SystemCredentialsProvider'
+
+// use this ID to reference and configure credential usage in any jenkins job to acquire credentials
+final CREDENTIALS_ID = '59aaa22a-e04e-4909-9cc8-2ac406e002d0'
+
+def shouldCredentialsBeServicePrincipal(clientId, clientSecret) {
+        return (clientId != null && clientId != '') && (clientSecret != null && clientSecret != '')
+}
+
+def instance = Jenkins.get()
+def domain = Domain.global()
+def store = instance.getExtensionList(SYSTEM_CREDENTIALS_PROVIDER)[0].getStore()
+
+final subscriptionId = System.getenv('AZURE_SUBSCRIPTION_ID')
+final clientId = System.getenv('AZURE_CLIENT_ID')
+final clientSecret = System.getenv('AZURE_CLIENT_SECRET')
+
+// if there's a client ID and a client secret present, then it should be a service principal
+// otherwise, default to managed identity
+if (shouldCredentialsBeServicePrincipal(clientId, clientSecret)) {
+        final description = 'Azure Service Principal Credentials'
+        def servicePrincipalCredentials = new AzureCredentials(
+                CredentialsScope.GLOBAL, 
+                CREDENTIALS_ID, 
+                description,
+                subscriptionId,
+                clientId,
+                clientSecret)
+        store.addCredentials(domain, servicePrincipalCredentials)
+
+} else { // managed identity
+        // the env name is the target cloud type / scope for azure, e.g. commercial, Gov, etc. it has nothing to do with env variables
+        final azureEnvironmentName = 'Azure'
+        def managedIdentityCredentials = new AzureImdsCredentials(
+                CredentialsScope.GLOBAL, 
+                CREDENTIALS_ID, 
+                azureEnvironmentName)
+
+        managedIdentityCredentials.subscriptionId = subscriptionId
+        managedIdentityCredentials.clientId = clientId
+        store.addCredentials(domain, managedIdentityCredentials)
+}


### PR DESCRIPTION
- Dockerfile updated to pull all groovy files for init hooks
- Service Principal override based on presence of environment variables
- local docker compose updated to pass variables through to Jenkins for credentials.

#### setting service principal values locally

1. Set all the following variables
  ```
export AZURE_CLIENT_ID=
export AZURE_CLIENT_SECRET=
export AZURE_SUBSCRIPTION_ID=
  ```
2. Call `docker compose up` OR

```
docker run \
  -e DEFAULT_ADMIN_PASSWORD=admin \
  -e AZURE_SUBSCRIPTION_ID=${AZURE_SUBSCRIPTION_ID} \
  -e AZURE_CLIENT_ID=${AZURE_CLIENT_ID} \
  -e AZURE_CLIENT_SECRET=${AZURE_CLIENT_SECRET} \
  -p 8080:8080 jenkins:latest 
```