### PR TITLE
adding status endpoint

### DIFF
--- a/src/Core/Engine/EngineStatus.cs
+++ b/src/Core/Engine/EngineStatus.cs
@@ -1,0 +1,11 @@
+﻿using System;
+namespace Modm.Engine
+{
+	public class EngineStatus
+	{
+		public required bool IsHealthy { get; set; }
+		public required EngineType EngineType { get; set; }
+		public required string Version { get; set; }
+	}
+}
+

--- a/src/Core/Engine/EngineType.cs
+++ b/src/Core/Engine/EngineType.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Text.Json.Serialization;
+
+namespace Modm.Engine
+{
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public enum EngineType
+	{
+		Jenkins,
+		Bicep,
+		Arm,
+	}
+}
+

--- a/src/Core/Engine/IDeploymentEngine.cs
+++ b/src/Core/Engine/IDeploymentEngine.cs
@@ -3,5 +3,6 @@
     public interface IDeploymentEngine
     {
         Task<StartDeploymentResult> StartAsync(string artifactsUri);
+        Task<EngineStatus> GetStatus();
     }
 }

--- a/src/Core/Engine/Jenkins/JenkinsClientExtensions.cs
+++ b/src/Core/Engine/Jenkins/JenkinsClientExtensions.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using JenkinsNET;
+using System.Net.Http.Headers;
+using System.Text;
+using Microsoft.Extensions.Options;
+
+namespace Modm.Engine.Jenkins
+{
+    public static class JenkinsClientExtensions
+    {
+        public static async Task<EngineStatus> GetJenkinsStatusAsync(this IJenkinsClient client)
+        {
+            EngineStatus status = new EngineStatus { EngineType = EngineType.Jenkins, IsHealthy = false, Version = "Unknown"};
+
+            try
+            {
+                var jenkinsClient = client as JenkinsClient;
+                if (jenkinsClient == null)
+                {
+                    return status;
+                }
+
+                var plainTextBytes = System.Text.Encoding.UTF8.GetBytes($"{jenkinsClient.UserName}:{jenkinsClient.Password}");
+                var credential = Convert.ToBase64String(plainTextBytes);
+
+                using (HttpClient httpClient = new HttpClient())
+                {
+                    // Add Authorization header with the API token
+                    httpClient.DefaultRequestHeaders.Authorization =
+                        new AuthenticationHeaderValue(
+                            "Basic",
+                            credential);
+
+                    HttpResponseMessage response = await httpClient
+                        .GetAsync(jenkinsClient.BaseUrl);
+
+                    response.EnsureSuccessStatusCode();
+                    status.IsHealthy = true;
+                    string responseBody = await response.Content.ReadAsStringAsync();
+                    string xJenkinsHeader = response.Headers.GetValues("X-Jenkins").FirstOrDefault();
+                    status.Version = !string.IsNullOrEmpty(xJenkinsHeader) ? xJenkinsHeader : status.Version;
+                    return status;
+                }
+            }
+            catch (Exception ex)
+            {
+                return status;
+            }
+        }
+    }
+}
+

--- a/src/Core/Engine/JenkinsDeploymentEngine.cs
+++ b/src/Core/Engine/JenkinsDeploymentEngine.cs
@@ -19,6 +19,11 @@ namespace Modm.Engine
             this.client = client;
         }
 
+        public async Task<EngineStatus> GetStatus()
+        {
+            return await this.client.GetJenkinsStatusAsync();
+        }
+        
 
         /// <summary>
         /// starts a deployment

--- a/src/ServiceHost/ServiceHost.csproj
+++ b/src/ServiceHost/ServiceHost.csproj
@@ -22,6 +22,7 @@
     <!-- debug type embedded causes the PDB file to be included in the single file -->
     <DebugType>embedded</DebugType>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(RunConfiguration)' == 'Worker' " />
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Systemd" Version="7.0.0" />

--- a/src/WebHost/Status/StatusController.cs
+++ b/src/WebHost/Status/StatusController.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using JenkinsNET;
+using Modm.Engine.Jenkins;
+using Modm.Engine;
+
+// For more information on enabling MVC for empty projects, visit https://go.microsoft.com/fwlink/?LinkID=397860
+
+namespace WebHost.Status
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class StatusController : ControllerBase
+    {
+        private readonly IDeploymentEngine engine;
+
+        public StatusController(IDeploymentEngine engine)
+        {
+            this.engine = engine;
+        }
+
+        [HttpGet]
+        public async Task<EngineStatus> GetAsync()
+        {
+            return await this.engine.GetStatus();
+        }
+    }
+}
+

--- a/src/WebHost/WebHost.csproj
+++ b/src/WebHost/WebHost.csproj
@@ -35,6 +35,7 @@
     <None Include="$(SpaRoot)**" Exclude="$(SpaRoot)node_modules\**" />
     <None Remove="Deployments\" />
     <None Remove="Resources\" />
+    <None Remove="Status\" />
   </ItemGroup>
 
   <ItemGroup>
@@ -44,6 +45,7 @@
   <ItemGroup>
     <Folder Include="Deployments\" />
     <Folder Include="Resources\" />
+    <Folder Include="Status\" />
   </ItemGroup>
   <Target Name="DebugEnsureNodeEnv" BeforeTargets="Build" Condition=" '$(Configuration)' == 'Debug' And !Exists('$(SpaRoot)node_modules') ">
     <!-- Ensure Node.js is installed -->


### PR DESCRIPTION
### Summary

This PR creates a status endpoint for the JenkinsDeployment engine.
It does so by including the following modifications:

- extends the IDeploymentEngine interface to include Task<EngineStatus> GetStatus()
- creates the EngineType and EngineStatus types to support the method
- creates new StatusController
- uses extension methods to attach the GetStatus() method to the IJenkinsClient interface of JenkinsNET.

Closes #394 