### PR TITLE
Add managed identity monitoring to service host

### DIFF
--- a/build/managedapp/definition.json
+++ b/build/managedapp/definition.json
@@ -1,10 +1,4 @@
 {
   "deploymentType": "terraform",
-  "mainTemplate": "main.tf",
-  "scripts": {
-    "pre": [
-
-    ],
-
-  }
+  "mainTemplate": "main.tf"
 }

--- a/build/managedapp/definition.json
+++ b/build/managedapp/definition.json
@@ -1,3 +1,10 @@
 {
-  "deploymentType": "terraform"
+  "deploymentType": "terraform",
+  "mainTemplate": "main.tf",
+  "scripts": {
+    "pre": [
+
+    ],
+
+  }
 }

--- a/build/vmi/modm/files/docker-compose.yml
+++ b/build/vmi/modm/files/docker-compose.yml
@@ -9,8 +9,6 @@ services:
     volumes:
       - ${MODM_HOME}/service/Caddyfile:/etc/caddy/Caddyfile
     restart: unless-stopped
-    env_file:
-      - ${MODM_HOME}/service/.env
   modm:
     image: modm:latest
     container_name: modm
@@ -19,10 +17,8 @@ services:
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
       - ASPNETCORE_URLS=http://+:5000
-    env_file:
-      - ${MODM_HOME}/service/.env
     volumes:
-      - ${MODM_HOME}:${MODM_HOME}
+      - ${MODM_HOME}:/usr/local/modm
   jenkins:
     image: jenkins:latest
     container_name: jenkins

--- a/src/Core/Azure/IManagedIdentityService.cs
+++ b/src/Core/Azure/IManagedIdentityService.cs
@@ -2,6 +2,11 @@
 {
     public interface IManagedIdentityService
     {
+        /// <summary>
+        /// Is the service endpoint reachable
+        /// </summary>
+        /// <returns></returns>
+        Task<bool> IsAccessibleAsync();
         Task<ManagedIdentityInfo> GetAsync();
     }
 }

--- a/src/Core/Azure/IManagedIdentityService.cs
+++ b/src/Core/Azure/IManagedIdentityService.cs
@@ -6,7 +6,11 @@
         /// Is the service endpoint reachable
         /// </summary>
         /// <returns></returns>
-        Task<bool> IsAccessibleAsync();
-        Task<ManagedIdentityInfo> GetAsync();
+        /// <remarks>
+        /// if the request to the IMDS is not successful, then a managed identity isn't assigned to the
+        /// vm instance and we don't have an accessible identity to consume
+        /// </remarks>
+        Task<bool> IsAccessibleAsync(CancellationToken cancellationToken = default);
+        Task<ManagedIdentityInfo> GetAsync(CancellationToken cancellationToken = default);
     }
 }

--- a/src/Core/Azure/LocalManagedIdentityService.cs
+++ b/src/Core/Azure/LocalManagedIdentityService.cs
@@ -12,7 +12,10 @@ namespace Modm.Azure
         {
             return Task.FromResult(new ManagedIdentityInfo
             {
-
+                ClientId = Guid.Empty,
+                SubscriptionId = Guid.Empty,
+                ObjectId = Guid.Empty,
+                TenantId = Guid.Empty
             });
         }
     }

--- a/src/Core/Azure/LocalManagedIdentityService.cs
+++ b/src/Core/Azure/LocalManagedIdentityService.cs
@@ -18,6 +18,11 @@ namespace Modm.Azure
                 TenantId = Guid.Empty
             });
         }
+
+        public Task<bool> IsAccessibleAsync()
+        {
+            return Task.FromResult(true);
+        }
     }
 }
 

--- a/src/Core/Azure/LocalManagedIdentityService.cs
+++ b/src/Core/Azure/LocalManagedIdentityService.cs
@@ -8,7 +8,7 @@ namespace Modm.Azure
 		{
 		}
 
-        public Task<ManagedIdentityInfo> GetAsync()
+        public Task<ManagedIdentityInfo> GetAsync(CancellationToken cancellationToken = default)
         {
             return Task.FromResult(new ManagedIdentityInfo
             {
@@ -19,7 +19,7 @@ namespace Modm.Azure
             });
         }
 
-        public Task<bool> IsAccessibleAsync()
+        public Task<bool> IsAccessibleAsync(CancellationToken cancellationToken = default)
         {
             return Task.FromResult(true);
         }

--- a/src/Core/Azure/Model/AcquireTokenErrorResponse.cs
+++ b/src/Core/Azure/Model/AcquireTokenErrorResponse.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Text.Json.Serialization;
+
+namespace Modm.Azure
+{
+	record AcquireTokenErrorResponse
+    {
+        public const string InvalidRequestError = "invalid_request";
+
+        [JsonPropertyName("error")]
+        public required string Error { get; set; }
+
+        [JsonPropertyName("error_description")]
+        public required string ErrorDescription { get; set; }
+    }
+}
+

--- a/src/Core/Azure/Model/AcquireTokenResponse.cs
+++ b/src/Core/Azure/Model/AcquireTokenResponse.cs
@@ -3,7 +3,7 @@ using System.Text.Json.Serialization;
 
 namespace Modm.Azure
 {
-    class TokenResponse
+    record AcquireTokenResponse
     {
         [JsonPropertyName("access_token")]
         public required string AccessToken { get; set; }

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -26,8 +26,10 @@
 
   <ItemGroup>
     <None Remove="Configuration\" />
+    <None Remove="Azure\Model\" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Configuration\" />
+    <Folder Include="Azure\Model\" />
   </ItemGroup>
 </Project>

--- a/src/ServiceHost/Controller.cs
+++ b/src/ServiceHost/Controller.cs
@@ -107,15 +107,12 @@ namespace Modm.ServiceHost
             envFile.Set("SITE_ADDRESS", options.Fqdn);
             envFile.Set("ACME_ACCOUNT_EMAIL", "nowhere@nowhere.com");
 
-            if (environment.IsProduction())
-            {
-                var info = await managedIdentityService.GetAsync();
+            var info = await managedIdentityService.GetAsync();
 
-                // required by container environments to have managed identity flow from vm to container
-                envFile.Set("AZURE_CLIENT_ID", info.ClientId.ToString());
-                envFile.Set("AZURE_TENANT_ID", info.TenantId.ToString());
-                envFile.Set("AZURE_SUBSCRIPTION_ID", info.SubscriptionId.ToString());
-            }
+            // required by container environments to have managed identity flow from vm to container
+            envFile.Set("AZURE_CLIENT_ID", info.ClientId.ToString());
+            envFile.Set("AZURE_TENANT_ID", info.TenantId.ToString());
+            envFile.Set("AZURE_SUBSCRIPTION_ID", info.SubscriptionId.ToString());
 
             await envFile.SaveAsync();
         }

--- a/src/ServiceHost/Controller.cs
+++ b/src/ServiceHost/Controller.cs
@@ -6,6 +6,7 @@ using Modm.Configuration;
 using Modm.Azure;
 using MediatR;
 using Modm.ServiceHost.Extensions;
+using Modm.ServiceHost.Notifications;
 
 namespace Modm.ServiceHost
 {

--- a/src/ServiceHost/Controller.cs
+++ b/src/ServiceHost/Controller.cs
@@ -132,7 +132,8 @@ namespace Modm.ServiceHost
                         .UseContainer()
                         .UseCompose()
                         .AssumeComposeVersion(ComposeVersion.V2)
-                        .FromFile((TemplateString)options.ComposeFilePath);
+                        .FromFile((TemplateString)options.ComposeFilePath)
+                        .ServiceName("modm-service");
 
             using var envFile = await GetEnvFileAsync();
 

--- a/src/ServiceHost/Controller.cs
+++ b/src/ServiceHost/Controller.cs
@@ -76,7 +76,7 @@ namespace Modm.ServiceHost
 
         public Task StopAsync(CancellationToken cancellationToken = default)
         {
-            ComposeService?.Stop();
+            ComposeService.Stop();
             return Task.CompletedTask;
         }
 

--- a/src/ServiceHost/ControllerService.cs
+++ b/src/ServiceHost/ControllerService.cs
@@ -1,5 +1,7 @@
-﻿using Modm.Azure;
+﻿using MediatR;
+using Modm.Azure;
 using Modm.ServiceHost.Extensions;
+using Modm.ServiceHost.Notifications;
 
 namespace Modm.ServiceHost
 {
@@ -10,6 +12,8 @@ namespace Modm.ServiceHost
         private readonly ILogger<ControllerService> logger;
         private readonly IServiceProvider serviceProvider;
         private readonly IConfiguration config;
+
+        bool managedIdentityAcquired = false;
 
         public ControllerService(IMetadataService metadataService, IServiceProvider serviceProvider, IConfiguration config, ILogger<ControllerService> logger)
         {
@@ -23,6 +27,8 @@ namespace Modm.ServiceHost
         {
             logger.LogInformation("ServiceHost started.");
 
+            await WaitUntilManagedIdentityIsAcquired(stoppingToken);
+
             controller = ControllerBuilder.Create(this.logger)
                 .UseFqdn(await metadataService.GetFqdnAsync())
                 .UseComposeFile(GetComposeFilePath())
@@ -32,15 +38,45 @@ namespace Modm.ServiceHost
             await controller.StartAsync(stoppingToken);
         }
 
-        public override Task StopAsync(CancellationToken cancellationToken)
+        public override async Task StopAsync(CancellationToken cancellationToken)
         {
-            controller?.StopAsync(cancellationToken);
-            return base.StopAsync(cancellationToken);
+            if (controller != null)
+                await controller.StopAsync(cancellationToken);
+
+            await base.StopAsync(cancellationToken);
+        }
+
+        async Task WaitUntilManagedIdentityIsAcquired(CancellationToken cancellationToken)
+        {
+            logger.LogInformation("Waiting to initialize controller until managed identity is acquired");
+
+            while (!managedIdentityAcquired)
+            {
+                await Task.Delay(1000, cancellationToken);
+            }
+
+            logger.LogInformation("managed identity acquired. proceeding with controller initialization");
         }
 
         string GetComposeFilePath()
         {
             return Path.Combine(config.GetHomeDirectory(), "service/docker-compose.yml");
+        }
+
+        class ManagedIdentityAcquiredHandler : INotificationHandler<ManagedIdentityAcquired>
+        {
+            private readonly ControllerService service;
+
+            public ManagedIdentityAcquiredHandler(ControllerService service)
+            {
+                this.service = service;
+            }
+
+            public Task Handle(ManagedIdentityAcquired notification, CancellationToken cancellationToken)
+            {
+                service.managedIdentityAcquired = true;
+                return Task.CompletedTask;
+            }
         }
     }
 }

--- a/src/ServiceHost/IServiceCollectionExtensions.cs
+++ b/src/ServiceHost/IServiceCollectionExtensions.cs
@@ -1,0 +1,13 @@
+﻿using System;
+namespace Modm.ServiceHost
+{
+	public static class IServiceCollectionExtensions
+	{
+		public static IServiceCollection AddSingletonHostedService<T>(this IServiceCollection services) where T : class, IHostedService
+		{
+			services.AddSingleton<T>().AddHostedService(p => p.GetRequiredService<T>());
+			return services;
+        }
+	}
+}
+

--- a/src/ServiceHost/ManagedIdentityMonitorService.cs
+++ b/src/ServiceHost/ManagedIdentityMonitorService.cs
@@ -1,0 +1,36 @@
+﻿using Modm.Azure;
+using MediatR;
+using Modm.ServiceHost.Notifications;
+
+namespace Modm.ServiceHost
+{
+    /// <summary>
+    /// Monitors the availability of a managed identity being available. once it identifies
+    /// it can acquire, it acquires the information and notifies internally within
+    /// the service host
+    /// </summary>
+    public class ManagedIdentityMonitorService : BackgroundService
+	{
+        const int DefaultWaitDelaySeconds = 10;
+
+        private readonly IManagedIdentityService managedIdentityService;
+        private readonly IMediator mediator;
+
+        public ManagedIdentityMonitorService(IManagedIdentityService managedIdentityService, IMediator mediator)
+		{
+            this.managedIdentityService = managedIdentityService;
+            this.mediator = mediator;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            while (!await managedIdentityService.IsAccessibleAsync(stoppingToken))
+            {
+                await Task.Delay(DefaultWaitDelaySeconds * 1000, stoppingToken);
+            }
+
+            await mediator.Publish(new ManagedIdentityAcquired(), stoppingToken);
+        }
+    }
+}
+

--- a/src/ServiceHost/Notifications/ControllerStarted.cs
+++ b/src/ServiceHost/Notifications/ControllerStarted.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using MediatR;
 
-namespace Modm.ServiceHost
+namespace Modm.ServiceHost.Notifications
 {
+	/// <summary>
+	/// internal notification that the controller has been started
+	/// </summary>
 	public class ControllerStarted : INotification
 	{
 		public required string DeploymentsUrl { get; set; }

--- a/src/ServiceHost/Notifications/ManagedIdentityAcquired.cs
+++ b/src/ServiceHost/Notifications/ManagedIdentityAcquired.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using MediatR;
+using Modm.Azure;
+
+namespace Modm.ServiceHost.Notifications
+{
+	class ManagedIdentityAcquired : INotification
+	{
+	}
+}
+

--- a/src/ServiceHost/Program.cs
+++ b/src/ServiceHost/Program.cs
@@ -23,8 +23,9 @@ IHost host = Host.CreateDefaultBuilder(args)
         services.AddHttpClient();
         services.AddSingleton<ArtifactsWatcher>();
 
-        services.AddHostedService<ControllerService>();
-        services.AddHostedService<ArtifactsWatcherService>();
+        services.AddSingletonHostedService<ControllerService>();
+        services.AddSingletonHostedService<ArtifactsWatcherService>();
+        services.AddSingletonHostedService<ManagedIdentityMonitorService>();
 
         services.AddMediatR(c => c.RegisterServicesFromAssemblyContaining<ControllerService>());
     })

--- a/src/ServiceHost/ServiceHost.csproj
+++ b/src/ServiceHost/ServiceHost.csproj
@@ -53,8 +53,10 @@
   </ItemGroup>
   <ItemGroup>
     <None Remove="Extensions\" />
+    <None Remove="Notifications\" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Extensions\" />
+    <Folder Include="Notifications\" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Closes #425 


Example runtime log output post changes:
```
❯ dotnet run --environment Development
info: Modm.ServiceHost.ControllerService[0]
      ServiceHost started.
info: Modm.ServiceHost.ControllerService[0]
      Waiting to initialize controller until managed identity is acquired
info: Microsoft.Hosting.Lifetime[0]
      Application started. Press Ctrl+C to shut down.
info: Microsoft.Hosting.Lifetime[0]
      Hosting environment: Development
info: Microsoft.Hosting.Lifetime[0]
      Content root path: /src/ServiceHost
info: Modm.ServiceHost.ControllerService[0]
      managed identity acquired. proceeding with controller initialization
info: Modm.ServiceHost.Controller[0]
      FQDN: localhost
info: Modm.ServiceHost.Controller[0]
      Docker Compose state changed: Starting
info: Modm.ServiceHost.Controller[0]
      Docker Compose state changed: Running
info: Modm.ServiceHost.Controller[0]
      Engine check [17]. HTTP Status [OK]
info: Modm.ServiceHost.Controller[0]
      Running at: 09/15/2023 09:24:01 -04:00
info: Modm.ServiceHost.Controller[0]
      Docker Compose state: Running
info: Modm.ServiceHost.ArtifactsWatcher[0]
      Starting artifacts watcher
info: Modm.ServiceHost.ArtifactsWatcher[0]
      Artifacts watcher started. Watching: commercial-marketplace-offer-deploy/home
info: Modm.ServiceHost.ArtifactsWatcher[0]
      Artifacts watcher filter: artifacts.uri
info: Modm.ServiceHost.Controller[0]
      Running at: 09/15/2023 09:24:11 -04:00
info: Modm.ServiceHost.Controller[0]
      Docker Compose state: Running
^Cinfo: Microsoft.Hosting.Lifetime[0]
      Application is shutting down...
info: Modm.ServiceHost.Controller[0]
      Docker Compose state changed: Stopping
info: Modm.ServiceHost.Controller[0]
      Docker Compose state changed: Stopped
```