### PR TITLE
moving restart to correct level

### DIFF
--- a/build/vmi/modm/files/docker-compose.yml
+++ b/build/vmi/modm/files/docker-compose.yml
@@ -30,7 +30,7 @@ services:
     depends_on:
       jenkins:
         condition: service_healthy
-        restart: true
+    restart: unless-stopped
   jenkins:
     image: jenkins:latest
     container_name: jenkins


### PR DESCRIPTION
### Summary

The docker compose call is running into an issue starting the services.  The logs indicate that the restart property might be at the wrong level.

This PR moves the restart property from depends_on under the modm service up to a property on the service level.