### PR TITLE
dns label fix

### DIFF
--- a/build/managedapp/mainTemplate.json
+++ b/build/managedapp/mainTemplate.json
@@ -81,7 +81,7 @@
         "artifactsContainerLocation": "[substring(parameters('_artifactsLocation'), 0, lastIndexOf(parameters('_artifactsLocation'), '/'))]",
         "resourceId": "[resourceId('Microsoft.Network/publicIpAddresses', parameters('publicIpAddressName1'))]",
         "vmResourceId": "[resourceId(subscription().subscriptionId, resourceGroup().name, 'Microsoft.Compute/virtualMachines', parameters('virtualMachineName'))]",
-        "dnsLabel": "[concat('a', uniqueString(variables('vmResourceId')))]",
+        "dnsLabel": "[concat('modm', uniqueString(variables('vmResourceId')))]",
         "Owner": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')]",
         "userDataObject": {
             "artifactsUri": "[concat(variables('artifactsContainerLocation'), '/', 'content.zip')]"

--- a/build/managedapp/mainTemplate.json
+++ b/build/managedapp/mainTemplate.json
@@ -81,7 +81,7 @@
         "artifactsContainerLocation": "[substring(parameters('_artifactsLocation'), 0, lastIndexOf(parameters('_artifactsLocation'), '/'))]",
         "resourceId": "[resourceId('Microsoft.Network/publicIpAddresses', parameters('publicIpAddressName1'))]",
         "vmResourceId": "[resourceId(subscription().subscriptionId, resourceGroup().name, 'Microsoft.Compute/virtualMachines', parameters('virtualMachineName'))]",
-        "dnsLabel": "[uniqueString(variables('vmResourceId'))]",
+        "dnsLabel": "[concat('a', uniqueString(variables('vmResourceId')))]",
         "Owner": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')]",
         "userDataObject": {
             "artifactsUri": "[concat(variables('artifactsContainerLocation'), '/', 'content.zip')]"

--- a/src/Core/Azure/DefaultMetadataService.cs
+++ b/src/Core/Azure/DefaultMetadataService.cs
@@ -39,7 +39,7 @@ namespace Modm.Azure
         public async Task<string> GetFqdnAsync()
         {
             var metadata = await GetAsync();
-            var dnsLabel = ArmFunctions.UniqueString(metadata.Compute.ResourceId);
+            var dnsLabel = $"modm{ArmFunctions.UniqueString(metadata.Compute.ResourceId)}";
             return $"{dnsLabel}.{metadata.Compute.Location}.cloudapp.azure.com";
         }
 


### PR DESCRIPTION
### Summary

This PR fixes the issue with invalid dnsLabels being applied to the azure VM / nic.  It ensures that each uniqueString based on the resourceId of the vm, is prepended with 'modm'.  The backend is aware of this as well and is able to reproduce the same dnsLabel.