### PR TITLE
Bobjac/directory permissions

### DIFF
--- a/src/Core/Artifacts/ArtifactsFile.cs
+++ b/src/Core/Artifacts/ArtifactsFile.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO.Compression;
+using System.Security.AccessControl;
 using Modm.Deployments;
 
 namespace Modm.Artifacts
@@ -52,8 +53,30 @@ namespace Modm.Artifacts
             // unzip directly to ./content
             var destinationDirectoryName = Path.GetDirectoryName(filePath);
             ZipFile.ExtractToDirectory(filePath, destinationDirectoryName, overwriteFiles: true);
+            ChangeDirectoryPermissions()
 
             IsExtracted = true;
+        }
+
+        /// <summary>
+        /// This method will change the permissions of the directory to allow everyone to have full control
+        /// </summary>
+        /// <param name="directoryPath"></param>
+        /// <exception cref="DirectoryNotFoundException"></exception>
+        private void ChangeDirectoryPermissions(string directoryPath)
+        {
+            DirectoryInfo directoryInfo = new DirectoryInfo(directoryPath);
+
+            if (directoryInfo.Exists)
+            {
+                DirectorySecurity directorySecurity = directoryInfo.GetAccessControl();
+                directorySecurity.AddAccessRule(new FileSystemAccessRule("Everyone", FileSystemRights.FullControl, AccessControlType.Allow));
+                directoryInfo.SetAccessControl(directorySecurity);
+            }
+            else
+            {
+                throw new DirectoryNotFoundException($"Directory '{directoryPath}' does not exist.");
+            }
         }
 
         /// <summary>

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Azure.Deployments.Expression" Version="1.0.1040" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.0.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
+    <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Tests/Core/Artifacts/ArtifactsTests.cs
+++ b/test/Tests/Core/Artifacts/ArtifactsTests.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Mono.Unix.Native;
+using Modm.Artifacts;
+
+namespace Modm.Tests.Core.Artifacts
+{
+	public class ArtifactsTests
+	{
+		public ArtifactsTests()
+		{
+		}
+
+        [Fact]
+		public void ArtifactsCanChangeDirectoryPermissions()
+		{
+            string tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(tempDir);
+
+            try
+            {
+                // Act
+                var artifactsFile = new ArtifactsFile("");
+                artifactsFile.ChangeDirectoryPermissions(tempDir);
+
+                Stat stat;
+
+                if (Syscall.stat(tempDir, out stat) == 0)
+                {
+                    var mode = stat.st_mode;
+                    Assert.Equal("ACCESSPERMS, S_IFDIR", mode.ToString());
+                }
+                else
+                {
+                    Assert.Fail("Could not retrieve directory stats");
+                }
+            }
+            finally
+            {
+                // Clean up
+                Directory.Delete(tempDir, true);
+            }
+        }
+    }
+}
+

--- a/test/Tests/Tests.csproj
+++ b/test/Tests/Tests.csproj
@@ -21,11 +21,20 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Core\Core.csproj" />
     <ProjectReference Include="..\..\src\ServiceHost\ServiceHost.csproj" />
     <ProjectReference Include="..\..\src\WebHost\WebHost.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Remove="Core\" />
+    <None Remove="Core\Artifacts\" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Core\" />
+    <Folder Include="Core\Artifacts\" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
### Directory Permissions

This PR adds linux directory permissions after unzipping content.zip.  This is needed for Jenkins to properly execute the terraform jobs.

It uses the Mono package to ensure full access to the linux file system rather than .net core native packages.