### PR TITLE
Bobjac/464

### DIFF
--- a/src/Core/Deployments/Deployment.cs
+++ b/src/Core/Deployments/Deployment.cs
@@ -14,10 +14,6 @@ namespace Modm.Deployments
 
 		public DeploymentDefinition Definition { get; set; }
 
-        // TODO: handle redeploy for failures.
-        // For now, we are going to deploy based on either undefined (new) or if there was a failure
-        public bool IsStartable => Status == DeploymentStatus.Undefined || Status == DeploymentStatus.Failure;
-
 		public IEnumerable<DeploymentResource> Resources { get; set; }
 
 		public Deployment()

--- a/src/Core/Engine/Pipelines/StartDeploymentRequestPipeline.cs
+++ b/src/Core/Engine/Pipelines/StartDeploymentRequestPipeline.cs
@@ -98,7 +98,8 @@ namespace Modm.Engine.Pipelines
 
             await UpdateStatus(deployment);
 
-            if (!result.Deployment.IsStartable)
+            bool isStartable = await IsStartable(result.Deployment);
+            if (!isStartable)
             {
                 deployment.Id = -1;
                 result.Errors.Add("Deployment is not startable");
@@ -122,6 +123,43 @@ namespace Modm.Engine.Pipelines
 
             return result;
         }
+
+        private async Task<bool> IsStartable(Deployment deployment)
+        {
+            try
+            {
+                var queueItems = await client.Queue.GetAllItemsAsync();
+
+                if (queueItems.Any(item => item.Task?.Name == deployment.Definition.DeploymentType))
+                {
+                    logger.LogDebug($"Deployment {deployment.Definition.DeploymentType} is already in the queue.");
+                    return false;
+                }
+
+                
+                var lastBuild = await client.Builds.GetAsync<JenkinsBuildBase>(deployment.Definition.DeploymentType, "lastBuild");
+
+                if (lastBuild == null)
+                {
+                    logger.LogWarning($"Unable to fetch last build details for {deployment.Definition.DeploymentType}");
+                    return true;
+                }
+
+                if (lastBuild.Building.GetValueOrDefault(false) || !string.IsNullOrEmpty(lastBuild.Result))
+                {
+                    logger.LogDebug($"Deployment {deployment.Definition.DeploymentType} either is currently building or already completed.");
+                    return false;
+                }
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, $"Failed to check if the deployment is startable for {deployment.Definition.DeploymentType}");
+                return false;
+            }
+        }
+
 
         private async Task Publish(Deployment deployment, CancellationToken cancellationToken)
         {

--- a/src/Core/Engine/Pipelines/StartDeploymentRequestPipeline.cs
+++ b/src/Core/Engine/Pipelines/StartDeploymentRequestPipeline.cs
@@ -136,7 +136,6 @@ namespace Modm.Engine.Pipelines
                     return false;
                 }
 
-                
                 var lastBuild = await client.Builds.GetAsync<JenkinsBuildBase>(deployment.Definition.DeploymentType, "lastBuild");
 
                 if (lastBuild == null)

--- a/test/Tests/StartDeploymentRequestTests.cs
+++ b/test/Tests/StartDeploymentRequestTests.cs
@@ -35,10 +35,12 @@ namespace Modm.Tests
 			var builds = Substitute.For<JenkinsNET.JenkinsClientBuilds>();
 			builds.GetAsync<JenkinsBuildBase>(Arg.Any<string>(), Arg.Any<string>())
 				.Returns(new JenkinsBuildBase(new XDocument()));
-
             jenkinsClient.Builds.Returns(builds);
 
-
+            var jenkinsQueue = Substitute.For<JenkinsNET.JenkinsClientQueue>();
+			jenkinsQueue.GetAllItemsAsync().Returns(new JenkinsQueueItem[] { });
+			jenkinsClient.Queue.Returns(jenkinsQueue);
+            
             configuration = Substitute.For<IConfiguration>();
 
 			homePath = Path.GetTempPath();
@@ -60,8 +62,18 @@ namespace Modm.Tests
 
 		}
 
+        [Fact]
+		public async Task should_detect_not_startable()
+		{
+            var result = await pipeline.Execute(new StartDeploymentRequest
+            {
+                ArtifactsUri = "https://amastorageprodus.blob.core.windows.net/applicationdefinitions/A00B7_31E9F9A09FD24294A0A30101246D9700_D688E1539FCEA5BF3E9A2A0FE44B8625FE5CE8F431AD872520418A7B6116BCB8/f61384f88a23433f9b7943151d825d26/content.zip",
+                Parameters = new Dictionary<string, object>()
+            });
+        }
 
-		private StartDeploymentRequestPipeline GetInstance()
+
+        private StartDeploymentRequestPipeline GetInstance()
 		{
 			var services = new ServiceCollection();
 


### PR DESCRIPTION
### Summary

This PR looks to make the start of a deployment idempotent.  It does this by enhancing the IsStartable check for a Deployment.  The following checks are now implemented against the IJenkinsClient:

- Checks to see if there are an items in the jenkins queue for the deployment.Definition.DeploymentType
- Checks the "lastBuild" for the deployment.Definition.DeploymentType and returns true if it is null
- If lastBuild isn't null, check to see if it is building or has a result and return false if it does
