### PR TITLE
ci cd changes

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,92 @@
+name: Build and Publish Virtual Machine Images
+
+permissions:
+  id-token: write
+  contents: read
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+  workflow_dispatch:
+
+env:
+  image_version: ${{ vars.major_version_number }}.${{ vars.minor_version_number }}.${{ github.run_number }}
+
+  # reference
+  # conditional steps: https://www.meziantou.net/executing-github-actions-jobs-or-steps-only-when-specific-files-change.htm
+jobs:
+  build-publish-vmis:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    environment: dev  
+    env:
+      PKR_VAR_client_id: ${{ secrets.PACKER_CLIENT_ID }}
+      PKR_VAR_client_secret: ${{ secrets.PACKER_CLIENT_SECRET }}
+      PKR_VAR_subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      PKR_VAR_tenant_id: ${{ secrets.AZURE_TENANT_ID }}
+      PKR_VAR_resource_group: ${{ vars.resource_group }}
+      PKR_VAR_location: ${{ vars.location }}
+      PKR_VAR_image_gallery_name: ${{ vars.image_gallery_name }}
+      PKR_VAR_base_image_name: ${{ vars.base_image_name }}
+      PKR_VAR_build_resource_group_name: ${{ vars.build_resource_group_name }}
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: '100'
+  
+      # Give an id to the step, so we can reference it later
+    - name: Check If Base Image Should Be Built
+      id: check_base_changed
+      run: |
+        # Diff HEAD with the previous commit
+        diff=$(git diff --name-only HEAD^ HEAD)
+
+        if [ "$(echo $diff | grep -c "^build/vmi/modm-base")" -ge 1 ]; then
+          echo "base_changed=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "base_changed=false" >> "$GITHUB_OUTPUT"
+        fi
+    - name: Azure Login
+      uses: azure/login@v1
+      with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+    
+    - name: Install Packer
+      uses: hashicorp/packer-github-actions@master
+      with:
+        command: version
+        target: .
+  
+      # only build the VMI base if the base files have changed in some way
+      # This guarantees that the base image image will be built first if there's
+      # changes made to it. 
+      #
+      # Given that the modm vmi packer defaults to "latest" base image version,
+      # it will pick up the base VMI built here
+    - name: Build Base VMI
+      if: steps.check_base_changed.outputs.base_changed == 'true'
+      run: |
+        source ./build/vmi/scripts/nextversion.sh
+        local image_version=$(get_next_image_version \
+          --image-name ${{ vars.base_image_name }} \
+          --gallery-name ${{ vars.image_gallery_name }} \
+          --resource-group ${{ vars.resource_group }})
+
+        ./scripts/build-vmi.sh \
+          --image-name ${{ vars.base_image_name }} \
+          --image-version $image_version \
+          --image-offer ${{ vars.base_image_offer }} 
+ 
+    - name: Build VMI
+      run: |
+        ./scripts/build-vmi.sh \
+          --image-name ${{ vars.image_name }} \
+          --image-version ${{ env.image_version }} \
+          --image-offer ${{ vars.image_offer }} 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,18 +19,6 @@ jobs:
     strategy:
       matrix:
         dotnet-version: [ '7.0.x' ]
-    environment: dev  
-    env:
-      PKR_VAR_client_id: ${{ secrets.PACKER_CLIENT_ID }}
-      PKR_VAR_client_secret: ${{ secrets.PACKER_CLIENT_SECRET }}
-      PKR_VAR_subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-      PKR_VAR_tenant_id: ${{ secrets.AZURE_TENANT_ID }}
-      PKR_VAR_resource_group: ${{ vars.resource_group }}
-      PKR_VAR_location: ${{ vars.location }}
-      PKR_VAR_image_gallery_name: ${{ vars.image_gallery_name }}
-      PKR_VAR_base_image_name: ${{ vars.base_image_name }}
-      PKR_VAR_build_resource_group_name: ${{ vars.build_resource_group_name }}
-
     steps:
       - uses: actions/checkout@v4
       - name: Setup dotnet ${{ matrix.dotnet-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,20 +1,24 @@
-name: Build and Publish Virtual Machine Images
-
-permissions:
-  id-token: write
-  contents: read
+name: d
 
 on:
+  pull_request:
+    types:
+      - opened
+    # target only main branch that the PR is attempting to merge to
+    branches:
+      - main
+  # support manually triggering
   workflow_dispatch:
 
 env:
-  image_version: 0.0.${{ github.run_number }}
+  working_directory: src/
 
-  # reference
-  # conditional steps: https://www.meziantou.net/executing-github-actions-jobs-or-steps-only-when-specific-files-change.htm
 jobs:
-  build-vm-images:
+  build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        dotnet-version: [ '7.0.x' ]
     environment: dev  
     env:
       PKR_VAR_client_id: ${{ secrets.PACKER_CLIENT_ID }}
@@ -28,59 +32,38 @@ jobs:
       PKR_VAR_build_resource_group_name: ${{ vars.build_resource_group_name }}
 
     steps:
-    - name: Checkout Repository
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: '100'
-  
-      # Give an id to the step, so we can reference it later
-    - name: Check If Base Image Should Be Built
-      id: check_base_changed
-      run: |
-        # Diff HEAD with the previous commit
-        diff=$(git diff --name-only HEAD^ HEAD)
+      - uses: actions/checkout@v4
+      - name: Setup dotnet ${{ matrix.dotnet-version }}
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: ${{ matrix.dotnet-version }}
 
-        if [ "$(echo $diff | grep -c "^build/vmi/modm-base")" -ge 1 ]; then
-          echo "base_changed=true" >> "$GITHUB_OUTPUT"
-        else
-          echo "base_changed=false" >> "$GITHUB_OUTPUT"
-        fi
-    - name: Azure Login
-      uses: azure/login@v1
-      with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-    
-    - name: Install Packer
-      uses: hashicorp/packer-github-actions@master
-      with:
-        command: version
-        target: .
-  
-      # only build the VMI base if the base files have changed in some way
-      # This guarantees that the base image image will be built first if there's
-      # changes made to it. 
-      #
-      # Given that the modm vmi packer defaults to "latest" base image version,
-      # it will pick up the base VMI built here
-    - name: Build Base VMI
-      if: steps.check_base_changed.outputs.base_changed == 'true'
-      run: |
-        source ./build/vmi/scripts/nextversion.sh
-        local image_version=$(get_next_image_version \
-          --image-name ${{ vars.base_image_name }} \
-          --gallery-name ${{ vars.image_gallery_name }} \
-          --resource-group ${{ vars.resource_group }})
+      # print current dotnet version
+      - name: Display dotnet version
+        run: dotnet --version
 
-        ./scripts/build-vmi.sh \
-          --image-name ${{ vars.base_image_name }} \
-          --image-version $image_version \
-          --image-offer ${{ vars.base_image_offer }} 
- 
-    - name: Build VMI
-      run: |
-        ./scripts/build-vmi.sh \
-          --image-name ${{ vars.image_name }} \
-          --image-version ${{ env.image_version }} \
-          --image-offer ${{ vars.image_offer }} 
+      - name: Cache packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.nuget/packages
+          # Look to see if there is a cache hit for the corresponding requirements file
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget
+
+      - name: Build
+        run: dotnet build
+        working-directory: ${{ env.working_directory }}
+
+      - name: Test with the dotnet CLI
+        run: dotnet test --logger trx --results-directory "TestResults-${{ matrix.dotnet-version }}"
+        working-directory: ${{ env.working_directory }}
+
+      - name: Upload dotnet test results
+        uses: actions/upload-artifact@v3
+        # Use always() to always run this step to publish test results when there are test failures
+        if: ${{ always() }}
+        with:
+          name: dotnet-results-${{ matrix.dotnet-version }}
+          path: ${{ env.working_directory }}/TestResults-${{ matrix.dotnet-version }}
+        

--- a/.github/workflows/sccd.yml
+++ b/.github/workflows/sccd.yml
@@ -1,4 +1,4 @@
-name: Build Service Catalog Managed Application
+name: Build Service Catalog Managed Applications
 
 permissions:
   id-token: write
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 env:
-  app_version: 0.0.${{ github.run_number }}
+  app_version: ${{ vars.major_version_number }}.${{ vars.minor_version_number }}.${{ github.run_number }}
 
   # reference
   # conditional steps: https://www.meziantou.net/executing-github-actions-jobs-or-steps-only-when-specific-files-change.htm


### PR DESCRIPTION
### Changes
- changes the names of the workflows (CI is build and test, whereas CD is publish)
- Incorporated triggered publish on merge of a PR for the VMIs
- Now pulling variable values for major and minor version numbers

### New
- incorporates CI that builds our dotnet solution, runs the tests, and captures the output
- The CI will run on every PR'd branch to main