### PR TITLE
V2/cycle1

### DIFF
--- a/src/Core/Engine/JenkinsDeploymentEngine.cs
+++ b/src/Core/Engine/JenkinsDeploymentEngine.cs
@@ -15,12 +15,15 @@ namespace Modm.Engine
         private readonly DeploymentResourcesClient deploymentResourcesClient;
         private readonly IPipeline<StartDeploymentRequest, StartDeploymentResult> pipeline;
         private readonly IMetadataService metadataService;
-
         private readonly ILogger<JenkinsDeploymentEngine> logger;
 
-        public JenkinsDeploymentEngine(DeploymentFile file, JenkinsClientFactory clientFactory,
+        public JenkinsDeploymentEngine(DeploymentFile file,
+            JenkinsClientFactory clientFactory,
             DeploymentResourcesClient deploymentResourcesClient,
-            IPipeline<StartDeploymentRequest, StartDeploymentResult> pipeline, IMetadataService metadataService, ILogger<JenkinsDeploymentEngine> logger)
+            IPipeline<StartDeploymentRequest,
+            StartDeploymentResult> pipeline,
+            IMetadataService metadataService,
+            ILogger<JenkinsDeploymentEngine> logger)
         {
             this.file = file;
             this.clientFactory = clientFactory;

--- a/src/Core/Engine/JenkinsReadinessService.cs
+++ b/src/Core/Engine/JenkinsReadinessService.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Modm.Jenkins;
+using Modm.Jenkins.Client;
+using Polly;
+using Polly.Retry;
+
+namespace Modm.Engine
+{
+    /// <summary>
+    /// Monitors Jenkins to determine when it is ready to serve API requests
+    /// </summary>
+	public class JenkinsReadinessService : BackgroundService
+    {
+        private readonly string baseJenkinsUrl = "http://localhost:8080";
+        private const int DefaultWaitDelaySeconds = 30;
+        private const int MillisecondsInASecond = 1000;
+
+        private readonly IDeploymentEngine engine;
+        private readonly HttpClient httpClient;
+        private readonly ILogger<JenkinsReadinessService> logger;
+
+        private readonly AsyncRetryPolicy asyncRetryPolicy;
+
+        private readonly JenkinsOptions jenkinsOptions;
+        private bool isHealthy;
+        private EngineInfo engineInfo;
+
+        public JenkinsReadinessService(
+            IDeploymentEngine engine,
+            HttpClient httpClient,
+            IOptions<JenkinsOptions> options,
+            ILogger<JenkinsReadinessService> logger)
+		{
+            this.engine = engine;
+            this.httpClient = httpClient;
+            this.jenkinsOptions = options.Value;
+            this.logger = logger;
+            this.isHealthy = false;
+            this.engineInfo = EngineInfo.Default();
+
+            this.asyncRetryPolicy = Policy
+               .Handle<Exception>()
+               .WaitAndRetryForeverAsync(retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)));
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                if (await IsJenkinsLoginAvailableAsync())
+                {
+                    var engineInfo = await GetEngineInfoAsync();
+                    if (engineInfo != null && engineInfo.IsHealthy != this.isHealthy)
+                    {
+                        this.isHealthy = engineInfo.IsHealthy;
+                        PublishEngineInfo(engineInfo);
+                    }
+                }
+                else
+                {
+                    PublishEngineInfo(EngineInfo.Default());
+                }
+
+                await Task.Delay(DefaultWaitDelaySeconds * MillisecondsInASecond, stoppingToken);
+            }
+        }
+
+        private async Task<bool> IsJenkinsLoginAvailableAsync()
+        {
+            var jenkinsBaseUrl = this.jenkinsOptions.BaseUrl;
+            var result = await this.asyncRetryPolicy.ExecuteAsync(async () =>
+            {
+                var response = await httpClient.GetAsync($"{jenkinsBaseUrl}/login");
+                if (!response.IsSuccessStatusCode)
+                {
+                    this.logger.LogError($"The jenkins /login uri returned {response.StatusCode}");
+                }
+                return response.IsSuccessStatusCode;
+            });
+
+            return result;
+        }
+
+        private void PublishEngineInfo(EngineInfo engineInfo)
+        {
+            this.engineInfo = engineInfo;
+        }
+
+        private async Task<EngineInfo> GetEngineInfoAsync()
+        {
+            return await this.engine.GetInfo();
+        }
+
+        public EngineInfo GetEngineInfo()
+        {
+            return this.engineInfo;
+        }
+    }
+}
+

--- a/src/Core/Engine/JenkinsReadinessService.cs
+++ b/src/Core/Engine/JenkinsReadinessService.cs
@@ -14,7 +14,6 @@ namespace Modm.Engine
     /// </summary>
 	public class JenkinsReadinessService : BackgroundService
     {
-        private readonly string baseJenkinsUrl = "http://localhost:8080";
         private const int DefaultWaitDelaySeconds = 30;
         private const int MillisecondsInASecond = 1000;
 

--- a/src/Core/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Core/Extensions/IServiceCollectionExtensions.cs
@@ -65,6 +65,7 @@ namespace Modm.Extensions
             services.Configure<JenkinsOptions>(configuration.GetSection(JenkinsOptions.ConfigSectionKey));
 
             services.AddSingletonHostedService<JenkinsMonitorService>();
+            services.AddSingletonHostedService<JenkinsReadinessService>();
 
             services.AddMediatR(c =>
             {

--- a/src/Core/Jenkins/Client/JenkinsClientFactory.cs
+++ b/src/Core/Jenkins/Client/JenkinsClientFactory.cs
@@ -30,6 +30,7 @@ namespace Modm.Jenkins.Client
         public virtual async Task<IJenkinsClient> Create()
         {
             var apiToken = await GetApiToken();
+            //var apiToken = await apiTokenClient.Get();
             var jenkinsNetClient = new JenkinsNET.JenkinsClient(options.BaseUrl)
             {
                 UserName = options.UserName,

--- a/src/ServiceHost/Controller.cs
+++ b/src/ServiceHost/Controller.cs
@@ -149,6 +149,11 @@ namespace Modm.ServiceHost
             }
 
             var service = builder.RemoveOrphans()
+                        //.WaitForHttp("jenkins", "http://localhost:8080/login", timeout: 60000, (response, attempt) =>
+                        //{
+                        //    logger.LogInformation("Engine check [{attempt}]. HTTP Status [{statusCode}]", attempt, response.Code);
+                        //    return response.Code == System.Net.HttpStatusCode.OK ? 0 : 500;
+                        //})
                         .Build();
 
             service.StateChange += (object sender, StateChangeEventArgs e) =>

--- a/src/ServiceHost/DependencyInjection.cs
+++ b/src/ServiceHost/DependencyInjection.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Modm.Azure;
 using Modm.Deployments;
+using Modm.Engine;
 using Modm.Extensions;
 using Polly;
 

--- a/src/ServiceHost/EngineChecker.cs
+++ b/src/ServiceHost/EngineChecker.cs
@@ -3,48 +3,52 @@ using System.Net.Http;
 using System.Text.Json;
 using System.Threading.Tasks;
 using System.Timers;
+using Microsoft.Extensions.Logging;
 using Modm.Engine;
 
-public class EngineChecker
+namespace Modm.ServiceHost
 {
-    private readonly string baseUrl = "http://localhost:5000";
-    private readonly HttpClient httpClient;
-    ILogger<EngineChecker> logger;
+    public class EngineChecker
+    {
+        private readonly string baseUrl = "http://localhost:5000";
+        private readonly HttpClient httpClient;
+        ILogger<EngineChecker> logger;
 
-    public EngineChecker(HttpClient httpClient, ILogger<EngineChecker> logger)
-    {
-        this.httpClient = httpClient;
-        this.logger = logger;
-    }
-  
-    public async Task<bool> IsEngineHealthy()
-    {
-        try
+        public EngineChecker(HttpClient httpClient, ILogger<EngineChecker> logger)
         {
-            var response = await httpClient.GetAsync($"{this.baseUrl}/api/status");
-            if (!response.IsSuccessStatusCode)
+            this.httpClient = httpClient;
+            this.logger = logger;
+        }
+
+        public async Task<bool> IsEngineHealthy()
+        {
+            try
             {
-                this.logger.LogError($"Engine is not healthy. Status code: {response.StatusCode}");
+                var response = await httpClient.GetAsync($"{this.baseUrl}/api/status");
+                if (!response.IsSuccessStatusCode)
+                {
+                    this.logger.LogError($"Engine is not healthy. Status code: {response.StatusCode}");
+                    return false;
+                }
+
+                var jsonResponse = await response.Content.ReadAsStringAsync();
+                this.logger.LogInformation($"Engine status: {jsonResponse}");
+                var engineInfo = JsonSerializer.Deserialize<EngineInfo>(jsonResponse);
+                if (engineInfo == null)
+                {
+                    this.logger.LogError($"Engine is not healthy. Status data is null.");
+                    return false;
+                }
+                this.logger.LogInformation($"Engine status after deserialization: {engineInfo.IsHealthy}");
+                return engineInfo.IsHealthy;
+            }
+            catch (Exception ex)
+            {
+                this.logger.LogError(ex, null);
                 return false;
             }
-
-            var jsonResponse = await response.Content.ReadAsStringAsync();
-            this.logger.LogInformation($"Engine status: {jsonResponse}");
-            var engineInfo = JsonSerializer.Deserialize<EngineInfo>(jsonResponse);
-            if (engineInfo == null)
-            {
-                this.logger.LogError($"Engine is not healthy. Status data is null.");
-                return false;
-            }
-            this.logger.LogInformation($"Engine status after deserialization: {engineInfo.IsHealthy}");
-            return engineInfo.IsHealthy;
-        }
-        catch (Exception ex)
-        {
-            this.logger.LogError(ex, null);
-            return false;
         }
     }
-
 }
+
 

--- a/src/ServiceHost/PackageWatcherService.cs
+++ b/src/ServiceHost/PackageWatcherService.cs
@@ -5,6 +5,7 @@ using Modm.ServiceHost.Notifications;
 using Modm.Azure.Model;
 using Modm.Azure;
 using System.Text.Json;
+using Modm.Engine;
 
 namespace Modm.ServiceHost
 {
@@ -65,7 +66,6 @@ namespace Modm.ServiceHost
                 throw new InvalidOperationException("Cannot start installer package watcher. Options are null");
             }
 
-            
             if (this.userData == null)
             {
                 var base64UserData = await FetchBase64UserData(cancellation);

--- a/src/WebHost/Controllers/StatusController.cs
+++ b/src/WebHost/Controllers/StatusController.cs
@@ -10,16 +10,19 @@ namespace WebHost.Controllers
     public class StatusController : ControllerBase
     {
         private readonly IDeploymentEngine engine;
+        private readonly JenkinsReadinessService readinessService;
 
-        public StatusController(IDeploymentEngine engine)
+        public StatusController(IDeploymentEngine engine, JenkinsReadinessService readinessService)
         {
             this.engine = engine;
+            this.readinessService = readinessService;
         }
 
         [HttpGet]
-        public async Task<EngineInfo> GetAsync()
+        public EngineInfo Get()
         {
-            return await this.engine.GetInfo();
+            //return await this.engine.GetInfo();
+            return this.readinessService.GetEngineInfo();
         }
     }
 }

--- a/src/WebHost/Controllers/StatusController.cs
+++ b/src/WebHost/Controllers/StatusController.cs
@@ -10,19 +10,16 @@ namespace WebHost.Controllers
     public class StatusController : ControllerBase
     {
         private readonly IDeploymentEngine engine;
-        private readonly JenkinsReadinessService readinessService;
 
-        public StatusController(IDeploymentEngine engine, JenkinsReadinessService readinessService)
+        public StatusController(IDeploymentEngine engine)
         {
             this.engine = engine;
-            this.readinessService = readinessService;
         }
 
         [HttpGet]
-        public EngineInfo Get()
+        public async Task<EngineInfo> Get()
         {
-            //return await this.engine.GetInfo();
-            return this.readinessService.GetEngineInfo();
+            return await this.engine.GetInfo();
         }
     }
 }


### PR DESCRIPTION
### Summary

Moving all readiness checks for the deployment engine to a dedicated background service.

The Background service does the following:
- Polls to ensure the /login uri of the downstream engine is available
- Once the /login uri is available, it will get required tokens and make api calls to get EngineInfo
- Stores engine info locally in singleton BackgroundService (pattern is established already in PackageWatcherService)
- Checks periodically for readiness changes and Publishes changes.  For now, the publish is just updating the local state, but if we want to publish through mediator, this is where we would do it.

The BackgroundService is dependency injected into the status controller and used.  This will take pressure off the downstream system and cache the results.