### PR TITLE
Infrastructure settings for app services

### DIFF
--- a/templates/mainTemplate.json
+++ b/templates/mainTemplate.json
@@ -91,7 +91,7 @@
             "name": "[variables('clientAppName')]",
             "location": "[variables('location')]",
             "sku": {
-                "name": "S1"
+                "name": "B2"
             },
             "properties": {
                 "reserved": true
@@ -128,6 +128,7 @@
                         "[resourceId('Microsoft.AppConfiguration/configurationStores', variables('configStoreName'))]"
                     ],
                     "properties": {
+                        "ASPNETCORE_HTTPS_PORT": "443",
                         "WEBSITE_RUN_FROM_PACKAGE": "[variables('clientAppPackageUrl')]",
                         "Credentials": "[concat('@Microsoft.AppConfiguration(Endpoint=', reference(resourceId('Microsoft.AppConfiguration/configurationStores', variables('configStoreName'))).endpoint,'; Key=Credentials)')]",
                         "SigningKey": "[concat('@Microsoft.AppConfiguration(Endpoint=', reference(resourceId('Microsoft.AppConfiguration/configurationStores', variables('configStoreName'))).endpoint,'; Key=SigningKey)')]",
@@ -145,7 +146,8 @@
                     ],
                     "properties": {
                         "linuxFxVersion": "DOTNETCORE|7.0",
-                        "netFrameworkVersion": "7.0"
+                        "netFrameworkVersion": "7.0",
+                        "appCommandLine": "dotnet \"ClientApp.dll\""
                     }
                 },
                 {


### PR DESCRIPTION
Closes #570 

- sped up by > 50% to B2 plan
- Explicitly set the DLL to point to for start command (so app service wasn't searching
- Added app setting to fix error in asp.net trying to find SSL port implicitly