### PR TITLE
Template fixes and cleanup

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,6 +10,12 @@ on:
       - closed
     branches:
       - main
+    paths:
+      - 'build/container/**'
+      - 'build/vmi/**'
+      - 'jenkins/**'
+      - 'src/**'
+      - 'tests/**'
   workflow_dispatch:
 
 env:

--- a/cli/modm/installer/manifest.py
+++ b/cli/modm/installer/manifest.py
@@ -37,8 +37,6 @@ class ManifestInfo(Model):
 
         self.offer = OfferProperties()
 
-        print(f"Template type: {self._template_type}")
-
         if self._template_type == SolutionTemplateType.terraform:
             self.deployment_type = DeploymentType.terraform
         else:

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "commercial-marketplace-offer-deploy"
-version = "0.1.0"
+version = "2.0.0"
 authors = [
   { name="Kevin Hillinger", email="kevin.hillinger@outlook.com" },
 ]

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -35,4 +35,4 @@ include-package-data = true
 
 [tool.setuptools.packages.find]
 where = ["."] 
-exclude = ["tests*"]
+exclude = ["tests*", "devcli"]

--- a/templates/mainTemplate.json
+++ b/templates/mainTemplate.json
@@ -39,7 +39,7 @@
         "configStoreName": "[concat('modmconfig-', substring(uniqueString(resourceGroup().id), 0, 8))]",
         "clientAppName": "[concat('modm', substring(uniqueString(parameters('_artifactsLocation')), 0, 12))]",
         "clientAppUrl": "[parameters('applicationInstallerUrl')]",
-        "clientAppCredentials": "[base64(concat(parameters('applicationInstallerUserName'), '|', parameters('applicationInstallerPassword')))]",
+        "clientAppCredentials": "[base64(concat(trim(parameters('applicationInstallerUserName')), '|', trim(parameters('applicationInstallerPassword'))))]",
         "clientAppSigningKey": "[uniqueString(resourceGroup().id, variables('clientAppName'))]",
         "clientAppStorageAccountName": "[format('modm{0}', uniqueString(resourceGroup().id))]",
         "clientAppPackageUrl": "[concat(variables('artifactsContainerLocation'), '/', 'clientapp.zip')]",
@@ -137,10 +137,10 @@
                     "properties": {
                         "ASPNETCORE_HTTPS_PORT": "443",
                         "WEBSITE_RUN_FROM_PACKAGE": "[variables('clientAppPackageUrl')]",
-                        "Credentials": "[concat('@Microsoft.AppConfiguration(Endpoint=', reference(resourceId('Microsoft.AppConfiguration/configurationStores', variables('configStoreName'))).endpoint,'; Key=Credentials)')]",
-                        "SigningKey": "[concat('@Microsoft.AppConfiguration(Endpoint=', reference(resourceId('Microsoft.AppConfiguration/configurationStores', variables('configStoreName'))).endpoint,'; Key=SigningKey)')]",
-                        "BackendUrl": "[concat('@Microsoft.AppConfiguration(Endpoint=', reference(resourceId('Microsoft.AppConfiguration/configurationStores', variables('configStoreName'))).endpoint,'; Key=BackendUrl)')]",
-                        "DashboardUrl":"[concat('@Microsoft.AppConfiguration(Endpoint=', reference(resourceId('Microsoft.AppConfiguration/configurationStores', variables('configStoreName'))).endpoint,'; Key=SigningKey)')]"
+                        "Credentials": "[concat('@Microsoft.AppConfiguration(Endpoint=',reference(resourceId('Microsoft.AppConfiguration/configurationStores',variables('configStoreName'))).endpoint,';Key=Credentials)')]",
+                        "SigningKey": "[concat('@Microsoft.AppConfiguration(Endpoint=',reference(resourceId('Microsoft.AppConfiguration/configurationStores',variables('configStoreName'))).endpoint,';Key=SigningKey)')]",
+                        "BackendUrl": "[concat('@Microsoft.AppConfiguration(Endpoint=',reference(resourceId('Microsoft.AppConfiguration/configurationStores',variables('configStoreName'))).endpoint,';Key=BackendUrl)')]",
+                        "DashboardUrl":"[concat('@Microsoft.AppConfiguration(Endpoint=',reference(resourceId('Microsoft.AppConfiguration/configurationStores',variables('configStoreName'))).endpoint,';Key=SigningKey)')]"
                     }
                 },
                 {

--- a/templates/mainTemplate.json
+++ b/templates/mainTemplate.json
@@ -180,7 +180,6 @@
                 "name": "standard"
             },
             "dependsOn": [
-                "[resourceId('Microsoft.Web/sites', variables('clientAppName'))]"
             ],
             "properties": {},
             "resources": [

--- a/tests/UnitTests/AdminCredentialsProviderTests.cs
+++ b/tests/UnitTests/AdminCredentialsProviderTests.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.Extensions.Configuration;
+using Modm.Security;
+
+namespace Modm.Tests.UnitTests
+{
+    public class AdminCredentialsProviderTests
+	{
+        private const string fakeBase64EncodedCredentials = "YWRtaW58a2VoaWxsaWJpY2Vwc2ltcGxlMTk0";
+        private readonly IConfigurationRoot configuration;
+
+        public AdminCredentialsProviderTests()
+		{
+            this.configuration = new ConfigurationBuilder()
+               .AddInMemoryCollection(new Dictionary<string, string?> {
+                   { AdminCredentialsProvider.AppSettingsKeyName, fakeBase64EncodedCredentials}
+               }).Build();
+        }
+
+        [Fact]
+        public void should_decode_appsetting()
+        {
+            var provider = new AdminCredentialsProvider(configuration);
+            var exception = Record.Exception(() => provider.Get());
+            Assert.Null(exception);
+        }
+    }
+}

--- a/tests/UnitTests/AppConfigurationResourceTests.cs
+++ b/tests/UnitTests/AppConfigurationResourceTests.cs
@@ -7,13 +7,6 @@ namespace Modm.Tests.UnitTests
 {
 	public class AppConfigurationResourceTests
 	{
-        /// <summary>
-        /// The name of the ARM template variable that must have matching value
-        /// as the what is created by the AppConfigurationResource
-        /// </summary>
-        private const string templateVariableName = "configStoreName";
-        private const string templateVariableValue = "[concat('modmconfig-', substring(uniqueString(resourceGroup().id), 0, 8))]";
-
         private readonly ResourceId resourceGroupId;
         private readonly AppConfigurationResource resource;
 


### PR DESCRIPTION
- removed whitespaces from point appsettings values defined in mainTemplate for web app's appsettings
- added paths filter to cd workflow to avoid building VMI unless needed
- added unit test to admin credential provider to ensure tests pass for credentials as base64