### PR TITLE
fixing createuidef

### DIFF
--- a/build/managedapp/bicep/simple/createUiDefinition.json
+++ b/build/managedapp/bicep/simple/createUiDefinition.json
@@ -8,7 +8,8 @@
         ],
         "steps": [],
         "outputs": {
-            "location": "[location()]"
+            "location": "[location()]",
+            "artifactsLocationSasToken": ""
         }
     }
 }


### PR DESCRIPTION
### Summary

This PR fixes a bug in the simple bicep scenario where the output parameters of the createUiDefinition.json file don't match the input params of main.bice.